### PR TITLE
Fix potential error in version line processing by adding null check

### DIFF
--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -214,7 +214,7 @@ export class CommitCommand {
 
           // Post-processing: Replace incorrect version lines with correct ones in their proper position
           const versionSectionMatch = gitChanges.filesInfo.match(/📦 Version Changes:\n([\s\S]+)/);
-          if (versionSectionMatch) {
+          if (versionSectionMatch && versionSectionMatch[1]) {
             const versionLines = versionSectionMatch[1]
               .split('\n')
               .map(line => line.trim())


### PR DESCRIPTION
- Modified src/commands/commit.ts to add a check for version Section Match[] to prevent undefined errors when splitting version lines