### PR TITLE
Add new config subcommand to list and view prompt templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **config list-prompt-templates**: Fixed template validation bug where the command could display "undefined" for template content due to a mismatch between `VALID_TEMPLATES` and actual service keys. Added proper validation similar to config keys with helpful suggestions for similar template names.
 - **config list-prompt-templates**: Fixed inconsistent logger usage where the catch block was using the static `Logger.error` method instead of the configured logger instance. This ensures error logging properly respects the `--verbose` flag configuration.
+- **config list-prompt-templates**: Removed unsafe `as any` type assertion and improved type safety throughout the template validation process.
 
 ## [1.0.18] - 2025-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **config list-prompt-templates**: New subcommand to list all available built-in prompt templates and view the contents of any template. This makes it easy for users to discover and inspect the prompt templates used for commit message generation.
+
 ## [1.0.18] - 2025-07-05
 
 ## [1.0.17] - 2025-07-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **config list-prompt-templates**: New subcommand to list all available built-in prompt templates and view the contents of any template. This makes it easy for users to discover and inspect the prompt templates used for commit message generation.
 
+### Fixed
+
+- **config list-prompt-templates**: Fixed inconsistent logger usage where the catch block was using the static `Logger.error` method instead of the configured logger instance. This ensures error logging properly respects the `--verbose` flag configuration.
+
 ## [1.0.18] - 2025-07-05
 
 ## [1.0.17] - 2025-07-05

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -423,3 +423,5 @@ This invokes Prettier via npx, ensuring compatibility and avoiding Bun-specific 
 ## License
 
 By contributing to Ollama Git Commit, you agree that your contributions will be licensed under the project's MIT License.
+
+- When adding new config subcommands (e.g., under `src/cli/commands/config/`), update the README.md with usage and examples, and add an entry to CHANGELOG.md under [Unreleased].

--- a/README.md
+++ b/README.md
@@ -398,6 +398,45 @@ ollama-git-commit test benchmark
 
 ### Configuration Commands
 
+The `config` command provides advanced configuration management for the tool. You can manage models, set options, and now list and view prompt templates.
+
+#### List Available Prompt Templates
+
+You can list all available built-in prompt templates:
+
+```bash
+ollama-git-commit config list-prompt-templates
+```
+
+Example output:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📝 Available Prompt Templates
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+• default
+• conventional
+• simple
+• detailed
+
+To view a specific template, use:
+  ollama-git-commit config list-prompt-templates --name <template>
+
+Example:
+  ollama-git-commit config list-prompt-templates --name conventional
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+#### View the Contents of a Prompt Template
+
+To view the full contents of a specific template:
+
+```bash
+ollama-git-commit config list-prompt-templates --name detailed
+```
+
+This will print the full text of the selected prompt template, so you can see exactly what the AI will use.
+
 ```bash
 # Initialize default configuration
 ollama-git-commit config create user

--- a/src/cli/commands/config/index.ts
+++ b/src/cli/commands/config/index.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { registerCreateCommands } from './create';
 import { registerKeysCommands } from './keys';
 import { registerModelsCommands } from './models';
+import { registerPromptsCommands } from './prompts';
 import { registerRemoveCommands } from './remove';
 import { registerSetCommands } from './set';
 import { registerShowCommands } from './show';
@@ -16,4 +17,5 @@ export const registerConfigCommands = (program: Command) => {
   registerSetCommands(configCommand);
   registerShowCommands(configCommand);
   registerModelsCommands(configCommand);
+  registerPromptsCommands(configCommand);
 };

--- a/src/cli/commands/config/prompts.ts
+++ b/src/cli/commands/config/prompts.ts
@@ -1,7 +1,6 @@
 import { Command } from 'commander';
 import { VALID_TEMPLATES } from '../../../constants/prompts';
 import { ServiceFactory } from '../../../core/factory';
-import { Logger } from '../../../utils/logger';
 
 export const registerPromptsCommands = (configCommand: Command) => {
   configCommand
@@ -10,12 +9,13 @@ export const registerPromptsCommands = (configCommand: Command) => {
     .option('-n, --name <template>', 'Show contents of specific template')
     .option('-v, --verbose', 'Show detailed output')
     .action(async options => {
+      // Create services using the factory
+      const factory = ServiceFactory.getInstance();
+      const logger = factory.createLogger({
+        verbose: options.verbose,
+      });
+
       try {
-        // Create services using the factory
-        const factory = ServiceFactory.getInstance();
-        const logger = factory.createLogger({
-          verbose: options.verbose,
-        });
         const promptService = factory.createPromptService({
           verbose: options.verbose,
         });
@@ -70,7 +70,7 @@ export const registerPromptsCommands = (configCommand: Command) => {
           );
         }
       } catch (error) {
-        Logger.error('Failed to list prompt templates:', error);
+        logger.error('Failed to list prompt templates:', error);
         process.exit(1);
       }
     });

--- a/src/cli/commands/config/prompts.ts
+++ b/src/cli/commands/config/prompts.ts
@@ -1,0 +1,77 @@
+import { Command } from 'commander';
+import { VALID_TEMPLATES } from '../../../constants/prompts';
+import { ServiceFactory } from '../../../core/factory';
+import { Logger } from '../../../utils/logger';
+
+export const registerPromptsCommands = (configCommand: Command) => {
+  configCommand
+    .command('list-prompt-templates')
+    .description('List available prompt templates')
+    .option('-n, --name <template>', 'Show contents of specific template')
+    .option('-v, --verbose', 'Show detailed output')
+    .action(async options => {
+      try {
+        // Create services using the factory
+        const factory = ServiceFactory.getInstance();
+        const logger = factory.createLogger({
+          verbose: options.verbose,
+        });
+        const promptService = factory.createPromptService({
+          verbose: options.verbose,
+        });
+
+        const templates = promptService.getPromptTemplates();
+
+        if (options.name) {
+          // Show specific template contents
+          const templateName = options.name.toLowerCase();
+
+          if (!VALID_TEMPLATES.includes(templateName as any)) {
+            logger.error(`Template '${templateName}' not found.`);
+            logger.info(`Available templates: ${VALID_TEMPLATES.join(', ')}`);
+            process.exit(1);
+          }
+
+          const templateContent = templates[templateName];
+
+          console.log(
+            '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+          );
+          console.log(`📝 Prompt Template: ${templateName}`);
+          console.log(
+            '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+          );
+          console.log(templateContent);
+          console.log(
+            '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+          );
+        } else {
+          // List all available templates
+          console.log(
+            '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+          );
+          console.log('📝 Available Prompt Templates');
+          console.log(
+            '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+          );
+
+          Object.keys(templates).forEach(templateName => {
+            console.log(`• ${templateName}`);
+          });
+
+          console.log('');
+          console.log('To view a specific template, use:');
+          console.log('  ollama-git-commit config list-prompt-templates --name <template>');
+          console.log('');
+          console.log('Example:');
+          console.log('  ollama-git-commit config list-prompt-templates --name conventional');
+          console.log(
+            '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+          );
+        }
+      } catch (error) {
+        Logger.error('Failed to list prompt templates:', error);
+        process.exit(1);
+      }
+    });
+};

--- a/src/cli/commands/config/prompts.ts
+++ b/src/cli/commands/config/prompts.ts
@@ -1,6 +1,59 @@
 import { Command } from 'commander';
-import { VALID_TEMPLATES } from '../../../constants/prompts';
 import { ServiceFactory } from '../../../core/factory';
+import { ILogger } from '../../../core/interfaces';
+
+// Helper function to get template keys from the service
+function getTemplateKeys(): string[] {
+  const factory = ServiceFactory.getInstance();
+  const promptService = factory.createPromptService({ verbose: false });
+  const templates = promptService.getPromptTemplates();
+  return Object.keys(templates);
+}
+
+// Helper function to find similar template names
+function findSimilarTemplates(invalidTemplate: string, validTemplates: string[]): string[] {
+  const suggestions: string[] = [];
+
+  // Check for exact substring matches
+  for (const validTemplate of validTemplates) {
+    if (validTemplate.includes(invalidTemplate) || invalidTemplate.includes(validTemplate)) {
+      suggestions.push(validTemplate);
+    }
+  }
+
+  // Check for templates with similar length and common characters
+  for (const validTemplate of validTemplates) {
+    if (Math.abs(validTemplate.length - invalidTemplate.length) <= 2) {
+      const commonChars = [...invalidTemplate].filter(char => validTemplate.includes(char)).length;
+      const similarity = commonChars / Math.max(invalidTemplate.length, validTemplate.length);
+      if (similarity >= 0.6) {
+        suggestions.push(validTemplate);
+      }
+    }
+  }
+
+  // Remove duplicates and limit to 5 suggestions
+  return [...new Set(suggestions)].slice(0, 5);
+}
+
+// Helper function to validate template name
+function validateTemplateName(templateName: string, logger: ILogger): string {
+  const templateKeys = getTemplateKeys();
+
+  // Check if the template exists in the actual service
+  if (!templateKeys.includes(templateName)) {
+    const suggestions = findSimilarTemplates(templateName, templateKeys);
+    logger.error(`❌ Template '${templateName}' not found.`);
+    if (suggestions.length > 0) {
+      console.log('💡 Did you mean one of these?');
+      suggestions.forEach(suggestion => console.log(`   ${suggestion}`));
+    }
+    console.log(`\n💡 Available templates: ${templateKeys.join(', ')}`);
+    process.exit(1);
+  }
+
+  return templateName;
+}
 
 export const registerPromptsCommands = (configCommand: Command) => {
   configCommand
@@ -26,18 +79,21 @@ export const registerPromptsCommands = (configCommand: Command) => {
           // Show specific template contents
           const templateName = options.name.toLowerCase();
 
-          if (!VALID_TEMPLATES.includes(templateName as any)) {
-            logger.error(`Template '${templateName}' not found.`);
-            logger.info(`Available templates: ${VALID_TEMPLATES.join(', ')}`);
+          // Validate template name using the actual service keys
+          const validatedTemplateName = validateTemplateName(templateName, logger);
+          const templateContent = templates[validatedTemplateName];
+
+          // Additional safety check
+          if (!templateContent) {
+            logger.error(`❌ Template content for '${validatedTemplateName}' is undefined.`);
+            console.log(`💡 Available templates: ${Object.keys(templates).join(', ')}`);
             process.exit(1);
           }
-
-          const templateContent = templates[templateName];
 
           console.log(
             '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
           );
-          console.log(`📝 Prompt Template: ${templateName}`);
+          console.log(`📝 Prompt Template: ${validatedTemplateName}`);
           console.log(
             '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
           );

--- a/test/commands/config/prompts.test.ts
+++ b/test/commands/config/prompts.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+import { PROMPTS, VALID_TEMPLATES } from '../../../src/constants/prompts';
+import { PromptService } from '../../../src/core/prompt';
+import { Logger } from '../../../src/utils/logger';
+
+describe('Prompts Commands', () => {
+  describe('PromptService integration', () => {
+    test('should use PromptService to get templates', () => {
+      const logger = new Logger();
+      const promptService = new PromptService(logger);
+      const templates = promptService.getPromptTemplates();
+
+      expect(templates).toHaveProperty('default');
+      expect(templates).toHaveProperty('conventional');
+      expect(templates).toHaveProperty('simple');
+      expect(templates).toHaveProperty('detailed');
+      
+      expect(templates.default).toBe(PROMPTS.DEFAULT);
+      expect(templates.conventional).toBe(PROMPTS.CONVENTIONAL);
+      expect(templates.simple).toBe(PROMPTS.SIMPLE);
+      expect(templates.detailed).toBe(PROMPTS.DETAILED);
+    });
+
+    test('should validate template names correctly', () => {
+      expect(VALID_TEMPLATES).toContain('default');
+      expect(VALID_TEMPLATES).toContain('conventional');
+      expect(VALID_TEMPLATES).toContain('simple');
+      expect(VALID_TEMPLATES).toContain('detailed');
+      expect(VALID_TEMPLATES).toHaveLength(4);
+    });
+
+    test('should handle case-insensitive template names', () => {
+      const logger = new Logger();
+      const promptService = new PromptService(logger);
+      
+      // Test that createPromptFromTemplate handles case-insensitive names
+      expect(() => promptService.createPromptFromTemplate('DEFAULT')).toThrow();
+      expect(() => promptService.createPromptFromTemplate('default')).not.toThrow();
+      expect(() => promptService.createPromptFromTemplate('CONVENTIONAL')).toThrow();
+      expect(() => promptService.createPromptFromTemplate('conventional')).not.toThrow();
+    });
+
+    test('should throw error for invalid template names', () => {
+      const logger = new Logger();
+      const promptService = new PromptService(logger);
+      
+      expect(() => promptService.createPromptFromTemplate('invalid')).toThrow();
+      expect(() => promptService.createPromptFromTemplate('')).toThrow();
+      expect(() => promptService.createPromptFromTemplate('nonexistent')).toThrow();
+    });
+  });
+
+  describe('Template content validation', () => {
+    test('should have non-empty template content', () => {
+      const logger = new Logger();
+      const promptService = new PromptService(logger);
+      const templates = promptService.getPromptTemplates();
+
+      Object.entries(templates).forEach(([name, content]) => {
+        expect(content).toBeTruthy();
+        expect(typeof content).toBe('string');
+        expect(content.length).toBeGreaterThan(0);
+        expect(content).toContain('commit message');
+      });
+    });
+
+    test('should have unique template content', () => {
+      const logger = new Logger();
+      const promptService = new PromptService(logger);
+      const templates = promptService.getPromptTemplates();
+
+      const contents = Object.values(templates);
+      const uniqueContents = new Set(contents);
+      
+      expect(uniqueContents.size).toBe(contents.length);
+    });
+  });
+}); 

--- a/test/commands/config/prompts.test.ts
+++ b/test/commands/config/prompts.test.ts
@@ -75,4 +75,78 @@ describe('Prompts Commands', () => {
       expect(uniqueContents.size).toBe(contents.length);
     });
   });
-}); 
+
+  describe('Template validation functions', () => {
+    test('should get template keys from service', () => {
+      const logger = new Logger();
+      const promptService = new PromptService(logger);
+      const templates = promptService.getPromptTemplates();
+      const templateKeys = Object.keys(templates);
+
+      expect(templateKeys).toContain('default');
+      expect(templateKeys).toContain('conventional');
+      expect(templateKeys).toContain('simple');
+      expect(templateKeys).toContain('detailed');
+      expect(templateKeys).toHaveLength(4);
+    });
+
+    test('should find similar template names', () => {
+      const validTemplates = ['default', 'conventional', 'simple', 'detailed'];
+      
+      // Test exact substring matches
+      const suggestions1 = findSimilarTemplates('def', validTemplates);
+      expect(suggestions1).toContain('default');
+      
+      // Test similar length and characters
+      const suggestions2 = findSimilarTemplates('convent', validTemplates);
+      expect(suggestions2).toContain('conventional');
+      
+      // Test no matches
+      const suggestions3 = findSimilarTemplates('xyz', validTemplates);
+      expect(suggestions3).toHaveLength(0);
+    });
+
+    test('should validate template names correctly', () => {
+      const logger = new Logger();
+      const promptService = new PromptService(logger);
+      const templates = promptService.getPromptTemplates();
+      const templateKeys = Object.keys(templates);
+
+      // Test valid template names
+      expect(templateKeys).toContain('default');
+      expect(templateKeys).toContain('conventional');
+      expect(templateKeys).toContain('simple');
+      expect(templateKeys).toContain('detailed');
+
+      // Test invalid template names
+      expect(templateKeys).not.toContain('invalid');
+      expect(templateKeys).not.toContain('nonexistent');
+    });
+  });
+});
+
+// Helper function for testing (copied from the prompts.ts file)
+function findSimilarTemplates(invalidTemplate: string, validTemplates: string[]): string[] {
+  const suggestions: string[] = [];
+
+  // Check for exact substring matches
+  for (const validTemplate of validTemplates) {
+    if (validTemplate.includes(invalidTemplate) || invalidTemplate.includes(validTemplate)) {
+      suggestions.push(validTemplate);
+    }
+  }
+
+  // Check for templates with similar length and common characters
+  for (const validTemplate of validTemplates) {
+    if (Math.abs(validTemplate.length - invalidTemplate.length) <= 2) {
+      const commonChars = [...invalidTemplate].filter(char => validTemplate.includes(char)).length;
+      const similarity = commonChars / Math.max(invalidTemplate.length, validTemplate.length);
+      if (similarity >= 0.6) {
+        suggestions.push(validTemplate);
+      }
+    }
+  }
+
+  // Remove duplicates and limit to 5 suggestions
+  return [...new Set(suggestions)].slice(0, 5);
+} 


### PR DESCRIPTION
## Changes

- CHANGELOG.md
  - Added entry for new 'config list-prompt-templates' subcommand
  - Added fix entry for inconsistent logger usage in 'config list-prompt-templates' subcommand
- CONTRIBUTING.md
  - Updated guidelines for adding config subcommands
- README.md
  - Added documentation for 'config list-prompt-templates' usage and examples
- src/cli/commands/config/index.ts
  - Registered new prompts command handler
- src/cli/commands/config/prompts.ts
  - Implemented new subcommand for listing/viewing prompt templates
- test/commands/config/prompts.test.ts
  - Added test cases for prompt template functionality
- Other Changes
  - Add new config subcommand to list and view prompt templates
  - Moved logger initialization inside action handler
  - src/cli/commands/config/prompts.ts:
  - Summary of changes
  - Updated error logging to use instance method instead of static Logger.error

## Summary

This PR includes changes from branch: **feat/issue-12-prompt-listing-cli-options** addresses issue: #12 

### Commit Count
- Total commits: 2